### PR TITLE
Cache Callers

### DIFF
--- a/src/main/java/com/nesaak/noreflection/NoReflection.java
+++ b/src/main/java/com/nesaak/noreflection/NoReflection.java
@@ -8,30 +8,57 @@ import com.nesaak.noreflection.access.FunctionalFieldAccess;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NoReflection {
 
-    private static final NoReflection SHARED_INSTANCE = new NoReflection();
+	private static final NoReflection SHARED_INSTANCE = new NoReflection();
 
-    public static NoReflection shared() {
-        return SHARED_INSTANCE;
-    }
+	private final Map<Field, FieldAccess> CACHED_FIELD_ACCESSORS = new ConcurrentHashMap<>();
+	private final Map<Constructor, DynamicCaller> CACHED_CONSTRUCTORS_CALLERS = new ConcurrentHashMap<>();
+	private final Map<Method, DynamicCaller> CACHED_METHOD_CALLERS = new ConcurrentHashMap<>();
 
-    private AccessManager manager = new AccessManager();
+	public static NoReflection shared() {
+		return SHARED_INSTANCE;
+	}
 
-    public AccessManager getManager() {
-        return manager;
-    }
+	private final AccessManager manager = new AccessManager();
 
-    public FieldAccess get(Field field) {
-        return new FunctionalFieldAccess(manager.getGetter(field), manager.getSetter(field));
-    }
+	public AccessManager getManager() {
+		return manager;
+	}
 
-    public DynamicCaller get(Constructor constructor) {
-        return new FunctionalCaller(manager.getConstructor(constructor));
-    }
+	public FieldAccess get(Field field) {
+		FieldAccess ret = CACHED_FIELD_ACCESSORS.get(field);
 
-    public DynamicCaller get(Method method) {
-        return new FunctionalCaller(manager.getMethod(method));
-    }
+		if (ret == null) {
+			ret = new FunctionalFieldAccess(manager.getGetter(field), manager.getSetter(field));
+			CACHED_FIELD_ACCESSORS.put(field, ret);
+		}
+
+		return ret;
+	}
+
+	public DynamicCaller get(Constructor constructor) {
+		DynamicCaller ret = CACHED_CONSTRUCTORS_CALLERS.get(constructor);
+
+		if (ret == null) {
+			ret = new FunctionalCaller(manager.getConstructor(constructor));
+			CACHED_CONSTRUCTORS_CALLERS.put(constructor, ret);
+		}
+
+		return ret;
+	}
+
+	public DynamicCaller get(Method method) {
+		DynamicCaller ret = CACHED_METHOD_CALLERS.get(method);
+
+		if (ret == null) {
+			ret = new FunctionalCaller(manager.getMethod(method));
+			CACHED_METHOD_CALLERS.put(method, ret);
+		}
+
+		return ret;
+	}
 }


### PR DESCRIPTION
In this pull request, I've changed the method, constructor, and field calls by default pull from our cache of all method calls. Should need a noticeable increase in performance due to not having to instantiate new instances.